### PR TITLE
Update CPAL dependency. Adds support for ASIO behind an `asio` feature flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_audio"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The audio API for Nannou, the creative coding framework."
 readme = "README.md"
@@ -11,7 +11,7 @@ homepage = "https://nannou.cc"
 edition = "2018"
 
 [dependencies]
-cpal = { git = "https://github.com/mitchmindtree/cpal", branch = "asio" }
+cpal = "0.10"
 failure = "0.1"
 sample = "0.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ homepage = "https://nannou.cc"
 edition = "2018"
 
 [dependencies]
-#cpal = "0.8"
 cpal = { git = "https://github.com/mitchmindtree/cpal", branch = "asio" }
 failure = "0.1"
 sample = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,10 @@ homepage = "https://nannou.cc"
 edition = "2018"
 
 [dependencies]
-cpal = "0.8"
+#cpal = "0.8"
+cpal = { git = "https://github.com/mitchmindtree/cpal", branch = "asio" }
+failure = "0.1"
 sample = "0.10"
+
+[features]
+asio = ["cpal/asio"]

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,3 +1,4 @@
+use crate::{DefaultFormatError, DeviceNameError, Format, SupportedFormatsError};
 use cpal::traits::DeviceTrait;
 use std::ops::Deref;
 
@@ -8,27 +9,25 @@ pub struct Device {
 
 /// An iterator yielding all available audio devices.
 pub struct Devices {
-    pub(crate) devices: cpal::platform::Devices,
+    pub(crate) devices: cpal::Devices,
 }
 
 /// An iterator yielding formats that are supported by the backend.
-pub type SupportedInputFormats = cpal::platform::SupportedInputFormats;
+pub type SupportedInputFormats = cpal::SupportedInputFormats;
 
 /// An iterator yielding formats that are supported by the backend.
-pub type SupportedOutputFormats = cpal::platform::SupportedOutputFormats;
+pub type SupportedOutputFormats = cpal::SupportedOutputFormats;
 
 impl Device {
     /// The unique name associated with this device.
-    pub fn name(&self) -> Result<String, cpal::DeviceNameError> {
+    pub fn name(&self) -> Result<String, DeviceNameError> {
         self.device.name()
     }
 
     /// An iterator yielding formats that are supported by the backend.
     ///
     /// Can return an error if the device is no longer valid (e.g. it has been disconnected).
-    pub fn supported_input_formats(
-        &self
-    ) -> Result<SupportedInputFormats, cpal::SupportedFormatsError> {
+    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats, SupportedFormatsError> {
         self.device.supported_input_formats()
     }
 
@@ -36,18 +35,18 @@ impl Device {
     ///
     /// Can return an error if the device is no longer valid (e.g. it has been disconnected).
     pub fn supported_output_formats(
-        &self
-    ) -> Result<SupportedOutputFormats, cpal::SupportedFormatsError> {
+        &self,
+    ) -> Result<SupportedOutputFormats, SupportedFormatsError> {
         self.device.supported_output_formats()
     }
 
     /// The default format used for input streams.
-    pub fn default_input_format(&self) -> Result<cpal::Format, cpal::DefaultFormatError> {
+    pub fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
         self.device.default_input_format()
     }
 
     /// The default format used for output streams.
-    pub fn default_output_format(&self) -> Result<cpal::Format, cpal::DefaultFormatError> {
+    pub fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
         self.device.default_output_format()
     }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,15 +1,14 @@
-use cpal::Device as DeviceTrait;
-use cpal::platform::{Device as CpalDevice, Devices as CpalDevices};
+use cpal::traits::DeviceTrait;
 use std::ops::Deref;
 
 /// A device that can be used to spawn an audio stream.
 pub struct Device {
-    pub(crate) device: CpalDevice,
+    pub(crate) device: cpal::Device,
 }
 
 /// An iterator yielding all available audio devices.
 pub struct Devices {
-    pub(crate) devices: CpalDevices,
+    pub(crate) devices: cpal::platform::Devices,
 }
 
 /// An iterator yielding formats that are supported by the backend.
@@ -72,7 +71,7 @@ impl Device {
 }
 
 impl Deref for Device {
-    type Target = CpalDevice;
+    type Target = cpal::Device;
     fn deref(&self) -> &Self::Target {
         &self.device
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,13 +1,15 @@
+use cpal::Device as DeviceTrait;
+use cpal::platform::{Device as CpalDevice, Devices as CpalDevices};
 use std::ops::Deref;
 
 /// A device that can be used to spawn an audio stream.
 pub struct Device {
-    pub(crate) device: cpal::Device,
+    pub(crate) device: CpalDevice,
 }
 
 /// An iterator yielding all available audio devices.
 pub struct Devices {
-    pub(crate) devices: cpal::Devices,
+    pub(crate) devices: CpalDevices,
 }
 
 impl Device {
@@ -31,7 +33,7 @@ impl Device {
 }
 
 impl Deref for Device {
-    type Target = cpal::Device;
+    type Target = CpalDevice;
     fn deref(&self) -> &Self::Target {
         &self.device
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -12,7 +12,46 @@ pub struct Devices {
     pub(crate) devices: CpalDevices,
 }
 
+/// An iterator yielding formats that are supported by the backend.
+pub type SupportedInputFormats = cpal::platform::SupportedInputFormats;
+
+/// An iterator yielding formats that are supported by the backend.
+pub type SupportedOutputFormats = cpal::platform::SupportedOutputFormats;
+
 impl Device {
+    /// The unique name associated with this device.
+    pub fn name(&self) -> Result<String, cpal::DeviceNameError> {
+        self.device.name()
+    }
+
+    /// An iterator yielding formats that are supported by the backend.
+    ///
+    /// Can return an error if the device is no longer valid (e.g. it has been disconnected).
+    pub fn supported_input_formats(
+        &self
+    ) -> Result<SupportedInputFormats, cpal::SupportedFormatsError> {
+        self.device.supported_input_formats()
+    }
+
+    /// An iterator yielding formats that are supported by the backend.
+    ///
+    /// Can return an error if the device is no longer valid (e.g. it has been disconnected).
+    pub fn supported_output_formats(
+        &self
+    ) -> Result<SupportedOutputFormats, cpal::SupportedFormatsError> {
+        self.device.supported_output_formats()
+    }
+
+    /// The default format used for input streams.
+    pub fn default_input_format(&self) -> Result<cpal::Format, cpal::DefaultFormatError> {
+        self.device.default_input_format()
+    }
+
+    /// The default format used for output streams.
+    pub fn default_output_format(&self) -> Result<cpal::Format, cpal::DefaultFormatError> {
+        self.device.default_output_format()
+    }
+
     /// The maximum number of output channels of any format supported by this device.
     pub fn max_supported_output_channels(&self) -> usize {
         self.supported_output_formats()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,7 @@
 //!   [**Requester**](./requester/struct.Requester.html) for buffering input and output streams that
 //!   may deliver buffers of inconsistent sizes into a stream of consistently sized buffers.
 
-use cpal::{EventLoop as EventLoopTrait, Host as HostTrait};
-use cpal::platform::{Host as CpalHost, EventLoop as CpalEventLoop};
+use cpal::traits::{EventLoopTrait, HostTrait};
 use std::marker::PhantomData;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
@@ -35,8 +34,8 @@ pub mod stream;
 
 /// The top-level audio API, for enumerating devices and spawning input/output streams.
 pub struct Host {
-    host: Arc<CpalHost>,
-    event_loop: Arc<CpalEventLoop>,
+    host: Arc<cpal::Host>,
+    event_loop: Arc<cpal::EventLoop>,
     process_fn_tx: Mutex<Option<mpsc::Sender<stream::ProcessFnMsg>>>,
 }
 
@@ -58,7 +57,7 @@ impl Host {
     }
 
     /// Initialise the `Host` from an existing CPAL host.
-    fn from_cpal_host(host: CpalHost) -> Self {
+    fn from_cpal_host(host: cpal::Host) -> Self {
         let host = Arc::new(host);
         let event_loop = Arc::new(host.event_loop());
         let process_fn_tx = Mutex::new(None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,14 +17,20 @@ use std::marker::PhantomData;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 
-pub use cpal;
-pub use cpal::HostUnavailable;
-pub use sample;
 pub use self::buffer::Buffer;
 pub use self::device::{Device, Devices};
 pub use self::receiver::Receiver;
 pub use self::requester::Requester;
 pub use self::stream::Stream;
+pub use cpal;
+#[doc(inline)]
+pub use cpal::{
+    BackendSpecificError, BuildStreamError, DefaultFormatError, DeviceNameError, DevicesError,
+    PauseStreamError, PlayStreamError, StreamError, SupportedFormatsError,
+};
+#[doc(inline)]
+pub use cpal::{Format, HostId, HostUnavailable, SupportedInputFormats, SupportedOutputFormats};
+pub use sample;
 
 pub mod buffer;
 pub mod device;
@@ -41,7 +47,7 @@ pub struct Host {
 
 impl Host {
     /// Instantiate the current host for the platform.
-    pub fn from_id(id: cpal::platform::HostId) -> Result<Self, cpal::HostUnavailable> {
+    pub fn from_id(id: HostId) -> Result<Self, HostUnavailable> {
         let host = cpal::host_from_id(id)?;
         Ok(Self::from_cpal_host(host))
     }
@@ -71,7 +77,7 @@ impl Host {
     /// Enumerate the available audio devices on the system.
     ///
     /// Produces an iterator yielding `Device`s.
-    pub fn devices(&self) -> Result<Devices, cpal::DevicesError> {
+    pub fn devices(&self) -> Result<Devices, DevicesError> {
         let devices = self.host.devices()?;
         Ok(Devices { devices })
     }
@@ -79,7 +85,7 @@ impl Host {
     /// Enumerate the available audio devices on the system that support input streams.
     ///
     /// Produces an iterator yielding `Device`s.
-    pub fn input_devices(&self) -> Result<stream::input::Devices, cpal::DevicesError> {
+    pub fn input_devices(&self) -> Result<stream::input::Devices, DevicesError> {
         let devices = self.host.input_devices()?;
         Ok(stream::input::Devices { devices })
     }
@@ -87,29 +93,30 @@ impl Host {
     /// Enumerate the available audio devices on the system that support output streams.
     ///
     /// Produces an iterator yielding `Device`s.
-    pub fn output_devices(&self) -> Result<stream::output::Devices, cpal::DevicesError> {
+    pub fn output_devices(&self) -> Result<stream::output::Devices, DevicesError> {
         let devices = self.host.output_devices()?;
         Ok(stream::output::Devices { devices })
     }
 
     /// The current default audio input device.
     pub fn default_input_device(&self) -> Option<Device> {
-        self.host.default_input_device().map(|device| Device { device })
+        self.host
+            .default_input_device()
+            .map(|device| Device { device })
     }
 
     /// The current default audio output device.
     pub fn default_output_device(&self) -> Option<Device> {
-        self.host.default_output_device().map(|device| Device { device })
+        self.host
+            .default_output_device()
+            .map(|device| Device { device })
     }
 
     /// Begin building a new input audio stream.
     ///
     /// If this is the first time a stream has been created, this method will spawn the
     /// `cpal::EventLoop::run` method on its own thread, ready to run built streams.
-    pub fn new_input_stream<M, S>(
-        &self,
-        model: M,
-    ) -> stream::input::BuilderInit<M, S> {
+    pub fn new_input_stream<M, S>(&self, model: M) -> stream::input::BuilderInit<M, S> {
         stream::input::Builder {
             capture: Default::default(),
             builder: self.new_stream(model),
@@ -120,10 +127,7 @@ impl Host {
     ///
     /// If this is the first time a stream has been created, this method will spawn the
     /// `cpal::EventLoop::run` method on its own thread, ready to run built streams.
-    pub fn new_output_stream<M, S>(
-        &self,
-        model: M,
-    ) -> stream::output::BuilderInit<M, S> {
+    pub fn new_output_stream<M, S>(&self, model: M) -> stream::output::BuilderInit<M, S> {
         stream::output::Builder {
             render: Default::default(),
             builder: self.new_stream(model),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use std::thread;
 
 pub use cpal;
 pub use cpal::HostUnavailable;
+pub use sample;
 pub use self::buffer::Buffer;
 pub use self::device::{Device, Devices};
 pub use self::receiver::Receiver;

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -40,16 +40,17 @@ where
     /// - `sample_rate` is not greater than `0`.
     /// - The number of `channels` is different to that with which the receiver was initialised.
     /// - The final input buffer frame does not contain a sample for every channel.
-    pub fn read_buffer<M, F>(
+    pub fn read_buffer<M, FA, FB>(
         &mut self,
         mut model: M,
-        capture: F,
+        capture: &stream::input::Capture<FA, FB>,
         input: &[S],
         channels: usize,
         sample_rate: u32,
     ) -> M
     where
-        F: stream::input::CaptureFn<M, S>,
+        FA: stream::input::CaptureFn<M, S>,
+        FB: stream::input::CaptureResultFn<M, S>,
     {
         let Receiver {
             ref mut samples,
@@ -92,7 +93,7 @@ where
                 channels,
                 sample_rate,
             };
-            capture(&mut model, &buffer);
+            capture.capture(&mut model, Ok(&buffer));
             std::mem::swap(samples, &mut buffer.interleaved_samples.into_vec());
             samples.clear();
         }

--- a/src/requester.rs
+++ b/src/requester.rs
@@ -36,16 +36,17 @@ where
     ///
     /// `Panic!`s if `sample_rate` is not greater than `0` or if the output buffer's length is not
     /// a multiple of the given number of channels.
-    pub fn fill_buffer<M, F>(
+    pub fn fill_buffer<M, FA, FB>(
         &mut self,
         mut model: M,
-        render: F,
+        render: &stream::output::Render<FA, FB>,
         output: &mut [S],
         channels: usize,
         sample_rate: u32,
     ) -> M
     where
-        F: stream::output::RenderFn<M, S>,
+        FA: stream::output::RenderFn<M, S>,
+        FB: stream::output::RenderResultFn<M, S>,
     {
         let Requester {
             ref mut samples,
@@ -128,7 +129,7 @@ where
                 channels,
                 sample_rate,
             };
-            render(&mut model, &mut buffer);
+            render.render(&mut model, Ok(&mut buffer));
             let mut new_samples = buffer.interleaved_samples.into_vec();
             std::mem::swap(samples, &mut new_samples);
 

--- a/src/stream/input.rs
+++ b/src/stream/input.rs
@@ -1,12 +1,12 @@
+use crate::{stream, Buffer, Device, Receiver, Stream, StreamError};
 use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
-use crate::{stream, Buffer, Device, Receiver, Stream};
 use sample::{FromSample, Sample, ToSample};
 use std::sync::atomic::AtomicBool;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
 /// The buffer if it is ready for reading, or an error if something went wrong with the stream.
-pub type Result<'a, S = f32> = std::result::Result<&'a Buffer<S>, cpal::StreamError>;
+pub type Result<'a, S = f32> = std::result::Result<&'a Buffer<S>, StreamError>;
 
 /// The function that will be called when a captured `Buffer` is ready to be read.
 pub trait CaptureFn<M, S>: Fn(&mut M, &Buffer<S>) {}
@@ -42,7 +42,7 @@ pub struct Builder<M, FA, FB, S = f32> {
 pub type BuilderInit<M, S = f32> =
     Builder<M, DefaultCaptureFn<M, S>, DefaultCaptureResultFn<M, S>, S>;
 
-type InputDevices = cpal::InputDevices<cpal::platform::Devices>;
+type InputDevices = cpal::InputDevices<cpal::Devices>;
 
 /// An iterator yielding all available audio devices that support input streams.
 pub struct Devices {
@@ -65,8 +65,8 @@ impl<A, B> Capture<A, B> {
                     Err(err) => {
                         panic!(
                             "An input stream error occurred: {}\nIf you wish to handle this \
-                            error within your code, consider building your input stream with \
-                            a `capture_result` function rather than a `capture` function.",
+                             error within your code, consider building your input stream with \
+                             a `capture_result` function rather than a `capture` function.",
                             err,
                         );
                     }
@@ -156,7 +156,9 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         let sample_format = super::cpal_sample_format::<S>();
 
         let device = match device {
-            None => host.default_input_device().ok_or(super::BuildError::DefaultDevice)?,
+            None => host
+                .default_input_device()
+                .ok_or(super::BuildError::DefaultDevice)?,
             Some(Device { device }) => device,
         };
 

--- a/src/stream/input.rs
+++ b/src/stream/input.rs
@@ -1,4 +1,4 @@
-use cpal::{Device as DeviceTrait, EventLoop as EventLoopTrait, Host as HostTrait};
+use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
 use crate::{stream, Buffer, Device, Receiver, Stream};
 use sample::{FromSample, Sample, ToSample};
 use std::sync::atomic::AtomicBool;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,5 +1,5 @@
-use cpal::traits::EventLoopTrait;
 use crate::Device;
+use cpal::traits::EventLoopTrait;
 use failure::Fail;
 use sample::Sample;
 use std;
@@ -79,13 +79,9 @@ pub enum BuildError {
     #[fail(display = "failed to get default device")]
     DefaultDevice,
     #[fail(display = "failed to enumerate available formats: {}", err)]
-    SupportedFormats {
-        err: cpal::SupportedFormatsError,
-    },
+    SupportedFormats { err: cpal::SupportedFormatsError },
     #[fail(display = "failed to build stream: {}", err)]
-    BuildStream {
-        err: cpal::BuildStreamError,
-    },
+    BuildStream { err: cpal::BuildStreamError },
 }
 
 impl LoopContext {

--- a/src/stream/output.rs
+++ b/src/stream/output.rs
@@ -1,4 +1,4 @@
-use cpal::{Device as DeviceTrait, EventLoop as EventLoopTrait, Host as HostTrait};
+use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
 use crate::{stream, Buffer, Device, Requester, Stream};
 use sample::{Sample, ToSample};
 use std::sync::atomic::AtomicBool;


### PR DESCRIPTION
This renames the `Api` type to `Host` to follow the convention set by CPAL in its v0.10.0 update.

Also adds some methods to the `Device` type that were originally acquired via the `Deref` implementation. This should improve visibility of the methods in the docs quite a bit!

Please see the commit messages below for more details!